### PR TITLE
fix: make getModuleVersion work with Deno wasm imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,37 @@ npm i @dprint/formatter
 
 ## Use
 
+Using [Deno wasm imports](https://docs.deno.com/runtime/reference/wasm/):
+
+```ts
+import * as mod from "https://plugins.dprint.dev/typescript-0.57.0.wasm";
+import { createFromWasmModule, GlobalConfiguration } from "@dprint/formatter";
+import { assertEquals } from "@std/assert";
+
+const globalConfig: GlobalConfiguration = {
+  indentWidth: 2,
+  lineWidth: 80,
+};
+const tsFormatter = await createFromWasmModule(mod);
+
+tsFormatter.setConfig(globalConfig, {
+  semiColons: "asi",
+});
+
+assertEquals(
+  "const t = 5\n",
+  tsFormatter.formatText({
+    filePath: "file.ts",
+    fileText: "const   t    = 5;",
+  }),
+);
+```
+
+Streaming from remote URL:
+
 ```ts
 import { createStreaming, GlobalConfiguration } from "@dprint/formatter";
+import { assertEquals } from "@std/assert";
 
 const globalConfig: GlobalConfiguration = {
   indentWidth: 2,
@@ -38,16 +67,18 @@ tsFormatter.setConfig(globalConfig, {
   semiColons: "asi",
 });
 
-// outputs: "const t = 5\n"
-console.log(tsFormatter.formatText({
-  filePath: "file.ts",
-  fileText: "const   t    = 5;",
-}));
+assertEquals(
+  "const t = 5\n",
+  tsFormatter.formatText({
+    filePath: "file.ts",
+    fileText: "const   t    = 5;",
+  }),
+);
 ```
 
 Using with plugins on npm (ex. [@dprint/json](https://www.npmjs.com/package/@dprint/json)):
 
-```ts
+```ts ignore
 import { createFromBuffer } from "@dprint/formatter";
 // You may have to use `getBuffer` on plugins that haven't updated yet.
 // See the plugins README.md for details.

--- a/mod.ts
+++ b/mod.ts
@@ -60,22 +60,16 @@ export function createFromBuffer(wasmModuleBuffer: BufferSource): Formatter {
 
 export function createFromWasmModule(wasmModule: WebAssembly.Module): Formatter {
   const version = getModuleVersionOrThrow(wasmModule);
-  if (version === 3) {
-    const host = v3.createHost();
-    const wasmInstance = new WebAssembly.Instance(
-      wasmModule,
-      host.createImportObject(),
-    );
-    return v3.createFromInstance(wasmInstance, host);
-  } else {
-    const _assert4: 4 = version;
-    const host = v4.createHost();
-    const wasmInstance = new WebAssembly.Instance(
-      wasmModule,
-      host.createImportObject(),
-    );
-    return v4.createFromInstance(wasmInstance, host);
-  }
+  const v = version === 3 ? v3 : v4;
+  const host = v.createHost();
+
+  // Deno wasm imports are typed as WebAssembly.Module, but imported as plain JS module
+  const wasmInstance: WebAssembly.Instance =
+    wasmModule instanceof WebAssembly.Module
+      ? new WebAssembly.Instance(wasmModule, host.createImportObject())
+      : { exports: wasmModule };
+
+  return v.createFromInstance(wasmInstance, host);
 }
 
 function getModuleVersionOrThrow(module: WebAssembly.Module): 3 | 4 {

--- a/mod.ts
+++ b/mod.ts
@@ -106,7 +106,12 @@ function getModuleVersion(module: WebAssembly.Module) {
     return undefined;
   }
 
-  const exports = WebAssembly.Module.exports(module);
+  // Deno wasm imports are typed as WebAssembly.Module, but imported as plain JS module
+  const exports = module instanceof WebAssembly.Module
+    ? WebAssembly.Module.exports(module)
+    // deno-lint-ignore no-explicit-any
+    : Object.keys(module as any).map((name) => ({ name }));
+
   for (const e of exports) {
     const maybeVersion = getVersionFromExport(e.name);
     if (maybeVersion != null) {

--- a/mod.ts
+++ b/mod.ts
@@ -58,7 +58,37 @@ export function createFromBuffer(wasmModuleBuffer: BufferSource): Formatter {
   return createFromWasmModule(wasmModule);
 }
 
-export function createFromWasmModule(wasmModule: WebAssembly.Module): Formatter {
+/**
+ * Creates a formatter from the specified wasm module.
+ * @param wasmModule - Wasm module instance or Deno wasm imports.
+ *
+ * ```ts
+ * import * as mod from "https://plugins.dprint.dev/typescript-0.57.0.wasm";
+ * import { createFromWasmModule, GlobalConfiguration } from "@dprint/formatter";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const globalConfig: GlobalConfiguration = {
+ *   indentWidth: 2,
+ *   lineWidth: 80,
+ * };
+ * const tsFormatter = await createFromWasmModule(mod);
+ *
+ * tsFormatter.setConfig(globalConfig, {
+ *   semiColons: "asi",
+ * });
+ *
+ * assertEquals(
+ *   "const t = 5\n",
+ *   tsFormatter.formatText({
+ *     filePath: "file.ts",
+ *     fileText: "const   t    = 5;",
+ *   }),
+ * );
+ * ```
+ */
+export function createFromWasmModule(
+  wasmModule: WebAssembly.Module,
+): Formatter {
   const version = getModuleVersionOrThrow(wasmModule);
   const v = version === 3 ? v3 : v4;
   const host = v.createHost();

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,6 +1,12 @@
 import { assertEquals } from "@std/assert";
 import * as fs from "node:fs";
-import { createFromBuffer, createStreaming, type Formatter, type GlobalConfiguration } from "./mod.ts";
+import {
+  createFromBuffer,
+  createFromWasmModule,
+  createStreaming,
+  type Formatter,
+  type GlobalConfiguration,
+} from "./mod.ts";
 
 Deno.test("it should create streaming", async () => {
   const formatter = await createStreaming(
@@ -13,6 +19,13 @@ Deno.test("it should create from buffer", async () => {
   const buffer = await fetch("https://plugins.dprint.dev/json-0.13.0.wasm")
     .then((r) => r.arrayBuffer());
   const formatter = createFromBuffer(buffer);
+  runGeneralJsonFormatterTests(formatter);
+});
+
+Deno.test("it should create from Deno wasm instance", async () => {
+  const mod = await import("https://plugins.dprint.dev/json-0.13.0.wasm");
+
+  const formatter = createFromWasmModule(mod);
   runGeneralJsonFormatterTests(formatter);
 });
 


### PR DESCRIPTION
## Summary

fixes #14

## Description

since Deno wasm imports are JS module but typed as `WebAssembly.Module`, emulated  `WebAssembly.Instance` using `{ exports: wasmModule }` hack.